### PR TITLE
Add support for GitHub Enterprise.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ dependencies:
 	dep ensure -v
 
 clean:
-	rm -f cover.out
+	rm -rf dist/ cover.out
 
 build:
 	go build

--- a/core/core.go
+++ b/core/core.go
@@ -17,7 +17,7 @@ import (
 // Execute core process
 func Execute(config types.Configuration) error {
 	ctx := context.Background()
-	client := gh.NewGitHubClient(ctx, config.GitHubToken)
+	client := gh.NewGitHubClient(ctx, config.GitHubToken, config.GitHubURL)
 
 	repoID := types.RepoID{
 		Owner:          config.Owner,

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/containous/lobicornis/types"
@@ -162,7 +163,7 @@ func IsOnMainRepository(pr *github.PullRequest) bool {
 }
 
 // NewGitHubClient create a new GitHub client
-func NewGitHubClient(ctx context.Context, token string) *github.Client {
+func NewGitHubClient(ctx context.Context, token string, gitHubURL *url.URL) *github.Client {
 	var client *github.Client
 	if len(token) == 0 {
 		client = github.NewClient(nil)
@@ -173,6 +174,11 @@ func NewGitHubClient(ctx context.Context, token string) *github.Client {
 		tc := oauth2.NewClient(ctx, ts)
 		client = github.NewClient(tc)
 	}
+
+	if gitHubURL != nil {
+		client.BaseURL = gitHubURL
+	}
+
 	return client
 }
 

--- a/lobicornis.go
+++ b/lobicornis.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"time"
@@ -91,6 +92,11 @@ func runCommand(config *types.Configuration) func() error {
 			return err
 		}
 
+		err = setGitHubURL(config)
+		if err != nil {
+			return err
+		}
+
 		return launch(config)
 	}
 }
@@ -101,6 +107,17 @@ func launch(config *types.Configuration) error {
 		return server.ListenAndServe()
 	}
 	return core.Execute(*config)
+}
+
+func setGitHubURL(config *types.Configuration) error {
+	if len(config.APIURL) > 0 {
+		baseURL, err := url.Parse(config.APIURL)
+		if err != nil {
+			return err
+		}
+		config.GitHubURL = baseURL
+	}
+	return nil
 }
 
 func validateConfig(config *types.Configuration) error {

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Usage: lobicornis [--flag=flag_argument] [-f[flag_argument]] ...     set flag_ar
    or: lobicornis [--flag[=true|false| ]] [-f[true|false| ]] ...     set true/false to boolean flag(s)
 
 Available Commands:
-	version                                            Display the version.
+        version                                            Display the version.
 Use "lobicornis [command] --help" for more information about a command.
 
 Flags:
@@ -21,6 +21,7 @@ Flags:
     --force-up-to-date           Forcing need up-to-date. (check-up-to-date must be false)               (default "true")
     --git-email                  Git user email.
     --git-name                   Git user name.
+    --github-url                 GitHub API URL (GitHub Enterprise) [optional]
     --marker                     GitHub Labels.                                                          (default "true")
     --marker.light-review        Label use when a pull request need a lower minimal review as default.   (default "bot/light-review")
     --marker.merge-in-progress   Label use when the bot update the PR (merge/rebase).                    (default "status/4-merge-in-progress")
@@ -44,7 +45,7 @@ Flags:
     --server                     Server mode.                                                            (default "false")
     --ssh                        Use SSH instead HTTPS.                                                  (default "false")
 -t, --token                      GitHub Token. [required]
--h, --help                       Print Help (this message) and exit
+-h, --help                       Print Help (this message) and exit 
 ```
 
 ## Description

--- a/types/types.go
+++ b/types/types.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"net/url"
+
 	"github.com/containous/flaeg"
 )
 
@@ -39,6 +41,8 @@ type Configuration struct {
 	NeedMilestone      bool          `long:"need-milestone" description:"Forcing PR to have a milestone."`
 	GitUserEmail       string        `long:"git-email" description:"Git user email."`
 	GitUserName        string        `long:"git-name" description:"Git user name."`
+	APIURL             string        `long:"github-url" description:"GitHub API URL (GitHub Enterprise) [optional]"`
+	GitHubURL          *url.URL      // related to "github-url"
 }
 
 // LabelMarkers Labels use to control actions.


### PR DESCRIPTION
Add support for GitHub Enterprise.

Example:
```bash
lobicornis --debug --ssh -t xxxxxxxxxxxxx -o foo -r bar --github-url="https://foobar.com"
```

Fixes #12