### PR TITLE
fix(mjolnir): close every issue referenced in a merged PR body

### DIFF
--- a/.github/workflows/go-cross.yml
+++ b/.github/workflows/go-cross.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         go-version: [ stable ]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/manual-test-mjolnir.md
+++ b/docs/manual-test-mjolnir.md
@@ -5,9 +5,11 @@ End-to-end manual test for the `Fixes/Closes/Resolves` issue parser in
 with dry-run **off** so issues actually close.
 
 > **Verify against the final state of the PR.** This runbook targets the core bug
-> fixes. The `mainBranch` constant in `mjolnir.go` is currently `"master"`; if that
-> handling changes, the "comment is skipped on the main branch" behavior shifts and
-> the notes below about base `main` always posting a comment may no longer hold.
+> fixes. The "comment is skipped on the default branch" behavior keys off the
+> repository's actual default branch (`pr.Base.Repo.DefaultBranch`), so it works
+> whether the default branch is `main`, `master`, or custom. Same-repo closes on a
+> default-branch PR skip the "Closed by" comment (GitHub auto-links); everything
+> else (non-default branch, cross-repo) still posts one.
 
 ## Behaviors under test (core)
 
@@ -66,9 +68,10 @@ extra:
 ```
 
 Defaults being overridden (see `pkg/conf/config.go`): `dryRun` defaults to true,
-`minReview` to 1, `needMilestone` to true. PR base is `main`; since the `mainBranch`
-constant is `"master"`, every same-repo close on a `main`-base PR posts a "Closed by"
-comment — expected, not the skip path.
+`minReview` to 1, `needMilestone` to true. The test repos use `main` as their
+default branch, so a same-repo close on a `main`-base PR takes the skip path (no
+"Closed by" comment — GitHub auto-links). To exercise the comment path, close from
+a non-default branch (e.g. a backport branch) or a cross-repo reference.
 
 ## PRs and expected results
 
@@ -90,6 +93,8 @@ Fixes https://github.com/traefik-workshops/repo-b/issues/b1
 
 Expected after the bot merges PR1:
 - `a1, a2, a3, a4, a5` CLOSED; `a3` closed exactly once (dedup of `#a3` + URL).
+- No "Closed by" comment on `a1`–`a5`: same-repo close on the default branch
+  (`main`) takes the skip path (GitHub auto-links).
 - `b1` stays OPEN; debug log shows the warn "repository not in allowCloseIssuesOn allow-list".
 
 ### RUN 2 — cross-repo allow
@@ -115,7 +120,7 @@ RUN 2. Watch the debug logs for `closes issue .../#N` lines and the allow-list w
 
 ## Verification checklist
 
-- [ ] `repo-a` `a1`–`a5` closed; `a3` not double-processed (single close, single comment).
+- [ ] `repo-a` `a1`–`a5` closed; `a3` not double-processed (single close, no comment — default-branch skip path).
 - [ ] `repo-b` `b1` OPEN after RUN 1 + warn logged (deny).
 - [ ] `repo-b` `b2` closed after RUN 2 + "Closed by" comment (allow).
 

--- a/docs/manual-test-mjolnir.md
+++ b/docs/manual-test-mjolnir.md
@@ -1,0 +1,125 @@
+# Manual test runbook — issue auto-closing (mjolnir)
+
+End-to-end manual test for the `Fixes/Closes/Resolves` issue parser in
+`pkg/repository/mjolnir.go`, run against a throwaway GitHub org (`traefik-workshops`)
+with dry-run **off** so issues actually close.
+
+> **Verify against the final state of the PR.** This runbook targets the core bug
+> fixes. The `mainBranch` constant in `mjolnir.go` is currently `"master"`; if that
+> handling changes, the "comment is skipped on the main branch" behavior shifts and
+> the notes below about base `main` always posting a comment may no longer hold.
+
+## Behaviors under test (core)
+
+1. **Multi-block** — multiple separate `Fixes ...` paragraphs → ALL closed
+   (regression: `FindStringSubmatch` only captured the first).
+2. **URL form same-repo** — `Fixes https://github.com/owner/repo/issues/N` → closed
+   (was: ignored, only `#NNN` matched).
+3. **Trailing period** — `Closes #N.` → closed (was: broken).
+4. **Cross-repo deny by default** — URL to a repo NOT in `allowCloseIssuesOn` →
+   ignored, warn logged, issue stays OPEN.
+5. **Cross-repo allow (exact)** — same URL after adding the repo to
+   `allowCloseIssuesOn` → closed + back-pointer comment.
+6. **Dedup** — `#N` and `.../issues/N` for the same issue → closed once.
+
+## Resources to create (2 repos, ~7 issues)
+
+### Repositories
+- `repo-a` — primary; PRs are created and merged here. Holds the same-repo issues.
+  Needs the `status/3-needs-merge` label defined.
+- `repo-b` — cross-repo target. Serves both the deny and the allow case via a config
+  flip between runs (deny first, then add to the allow-list).
+
+Each repo: one initial commit on the default branch `main`. Disable any branch
+protection that requires reviews or status checks — the bot cannot bypass GitHub
+branch protection; its own `minReview` is separate.
+
+### Issues
+- `repo-a`: `#a1, #a2` (multi-block), `#a3` (dedup: referenced as `#a3` AND as a URL),
+  `#a4` (URL same-repo), `#a5` (trailing period). = 5
+- `repo-b`: `#b1` (deny run — must stay OPEN), `#b2` (allow run — closed after the
+  config flip). = 2
+
+## Bot config (`lobicornis-test.yml`)
+
+```yaml
+github:
+  user: traefik-workshops          # search: "user:traefik-workshops type:pr state:open"
+  # token via GITHUB_TOKEN env (org PAT with repo + issues:write on both repos)
+
+git:
+  email: <bot-email>
+  userName: <bot-name>
+
+default:
+  mergeMethod: squash
+  minReview: 0                     # a single tester cannot approve their own PR; 0 = no approval needed
+  minLightReview: 0
+  needMilestone: false             # skip the milestone gate
+  checkNeedUpToDate: false         # avoid the rebase-via-git-clone path
+  forceNeedUpToDate: false
+  allowCloseIssuesOn: []           # RUN 1: empty (deny). RUN 2: add traefik-workshops/repo-b
+
+extra:
+  dryRun: false                    # REQUIRED so issues actually close (default is true; no CLI flag)
+  logLevel: debug
+```
+
+Defaults being overridden (see `pkg/conf/config.go`): `dryRun` defaults to true,
+`minReview` to 1, `needMilestone` to true. PR base is `main`; since the `mainBranch`
+constant is `"master"`, every same-repo close on a `main`-base PR posts a "Closed by"
+comment — expected, not the skip path.
+
+## PRs and expected results
+
+### RUN 1 — deny + same-repo behaviors
+
+Config: `allowCloseIssuesOn: []`. PR1 in `repo-a`, base `main`, label
+`status/3-needs-merge`, body:
+
+```
+This partially Fixes #a1 by proposing an alternative.
+
+Fixes #a2
+Fixes #a3
+Closes https://github.com/traefik-workshops/repo-a/issues/a3
+Resolves https://github.com/traefik-workshops/repo-a/issues/a4
+Closes #a5.
+Fixes https://github.com/traefik-workshops/repo-b/issues/b1
+```
+
+Expected after the bot merges PR1:
+- `a1, a2, a3, a4, a5` CLOSED; `a3` closed exactly once (dedup of `#a3` + URL).
+- `b1` stays OPEN; debug log shows the warn "repository not in allowCloseIssuesOn allow-list".
+
+### RUN 2 — cross-repo allow
+
+Edit config: `allowCloseIssuesOn: [ traefik-workshops/repo-b ]`. New PR2 in `repo-a`,
+base `main`, label `status/3-needs-merge`, body:
+
+```
+Fixes https://github.com/traefik-workshops/repo-b/issues/b2
+```
+
+Expected: `b2` CLOSED, with comment `Closed by traefik-workshops/repo-a#<PR2>.` on `b2`.
+
+## How to run
+
+```bash
+GITHUB_TOKEN=<org-pat> go run ./cmd -config ./lobicornis-test.yml
+```
+
+One-shot per invocation (no `-server`). The bot processes one PR per repo per run, so
+re-run until the labeled PR is picked up and merged. Flip the config between RUN 1 and
+RUN 2. Watch the debug logs for `closes issue .../#N` lines and the allow-list warn.
+
+## Verification checklist
+
+- [ ] `repo-a` `a1`–`a5` closed; `a3` not double-processed (single close, single comment).
+- [ ] `repo-b` `b1` OPEN after RUN 1 + warn logged (deny).
+- [ ] `repo-b` `b2` closed after RUN 2 + "Closed by" comment (allow).
+
+## Teardown
+
+Delete the 2 test repos once verified (or reopen the issues and close the PRs). Revoke
+the org PAT.

--- a/pkg/conf/config.go
+++ b/pkg/conf/config.go
@@ -163,8 +163,8 @@ func applyDefault(config *RepoConfig, cfg Configuration) {
 		config.CommitMessage = cfg.Default.CommitMessage
 	}
 
-	if config.CloseIssuesFrom == nil {
-		config.CloseIssuesFrom = cfg.Default.CloseIssuesFrom
+	if config.AllowCloseIssuesOn == nil {
+		config.AllowCloseIssuesOn = cfg.Default.AllowCloseIssuesOn
 	}
 }
 

--- a/pkg/conf/config.go
+++ b/pkg/conf/config.go
@@ -162,6 +162,10 @@ func applyDefault(config *RepoConfig, cfg Configuration) {
 	if config.CommitMessage == nil {
 		config.CommitMessage = cfg.Default.CommitMessage
 	}
+
+	if config.CloseIssuesFrom == nil {
+		config.CloseIssuesFrom = cfg.Default.CloseIssuesFrom
+	}
 }
 
 func validate(cfg Configuration) error {

--- a/pkg/conf/repo.go
+++ b/pkg/conf/repo.go
@@ -2,14 +2,15 @@ package conf
 
 // RepoConfig the repo configuration.
 type RepoConfig struct {
-	MergeMethod       *string `yaml:"mergeMethod,omitempty"`
-	MinLightReview    *int    `yaml:"minLightReview,omitempty"`
-	MinReview         *int    `yaml:"minReview,omitempty"`
-	NeedMilestone     *bool   `yaml:"needMilestone,omitempty"`
-	CheckNeedUpToDate *bool   `yaml:"checkNeedUpToDate,omitempty"`
-	ForceNeedUpToDate *bool   `yaml:"forceNeedUpToDate,omitempty"`
-	AddErrorInComment *bool   `yaml:"addErrorInComment,omitempty"`
-	CommitMessage     *string `yaml:"commitMessage,omitempty"`
+	MergeMethod       *string  `yaml:"mergeMethod,omitempty"`
+	MinLightReview    *int     `yaml:"minLightReview,omitempty"`
+	MinReview         *int     `yaml:"minReview,omitempty"`
+	NeedMilestone     *bool    `yaml:"needMilestone,omitempty"`
+	CheckNeedUpToDate *bool    `yaml:"checkNeedUpToDate,omitempty"`
+	ForceNeedUpToDate *bool    `yaml:"forceNeedUpToDate,omitempty"`
+	AddErrorInComment *bool    `yaml:"addErrorInComment,omitempty"`
+	CommitMessage     *string  `yaml:"commitMessage,omitempty"`
+	CloseIssuesFrom   []string `yaml:"closeIssuesFrom,omitempty"`
 }
 
 // GetMergeMethod gets merge method.
@@ -82,4 +83,11 @@ func (r *RepoConfig) GetCommitMessage() string {
 	}
 
 	return ""
+}
+
+// GetCloseIssuesFrom returns the list of repositories (owner/name, or owner/* wildcard)
+// whose issues may be auto-closed from a merged PR body.
+// The PR's own repository is always allowed regardless of this list.
+func (r *RepoConfig) GetCloseIssuesFrom() []string {
+	return r.CloseIssuesFrom
 }

--- a/pkg/conf/repo.go
+++ b/pkg/conf/repo.go
@@ -2,15 +2,15 @@ package conf
 
 // RepoConfig the repo configuration.
 type RepoConfig struct {
-	MergeMethod       *string  `yaml:"mergeMethod,omitempty"`
-	MinLightReview    *int     `yaml:"minLightReview,omitempty"`
-	MinReview         *int     `yaml:"minReview,omitempty"`
-	NeedMilestone     *bool    `yaml:"needMilestone,omitempty"`
-	CheckNeedUpToDate *bool    `yaml:"checkNeedUpToDate,omitempty"`
-	ForceNeedUpToDate *bool    `yaml:"forceNeedUpToDate,omitempty"`
-	AddErrorInComment *bool    `yaml:"addErrorInComment,omitempty"`
-	CommitMessage     *string  `yaml:"commitMessage,omitempty"`
-	CloseIssuesFrom   []string `yaml:"closeIssuesFrom,omitempty"`
+	MergeMethod        *string  `yaml:"mergeMethod,omitempty"`
+	MinLightReview     *int     `yaml:"minLightReview,omitempty"`
+	MinReview          *int     `yaml:"minReview,omitempty"`
+	NeedMilestone      *bool    `yaml:"needMilestone,omitempty"`
+	CheckNeedUpToDate  *bool    `yaml:"checkNeedUpToDate,omitempty"`
+	ForceNeedUpToDate  *bool    `yaml:"forceNeedUpToDate,omitempty"`
+	AddErrorInComment  *bool    `yaml:"addErrorInComment,omitempty"`
+	CommitMessage      *string  `yaml:"commitMessage,omitempty"`
+	AllowCloseIssuesOn []string `yaml:"allowCloseIssuesOn,omitempty"`
 }
 
 // GetMergeMethod gets merge method.
@@ -85,9 +85,9 @@ func (r *RepoConfig) GetCommitMessage() string {
 	return ""
 }
 
-// GetCloseIssuesFrom returns the list of repositories (owner/name, or owner/* wildcard)
+// GetAllowCloseIssuesOn returns the list of repositories (owner/name, or owner/* wildcard)
 // whose issues may be auto-closed from a merged PR body.
 // The PR's own repository is always allowed regardless of this list.
-func (r *RepoConfig) GetCloseIssuesFrom() []string {
-	return r.CloseIssuesFrom
+func (r *RepoConfig) GetAllowCloseIssuesOn() []string {
+	return r.AllowCloseIssuesOn
 }

--- a/pkg/repository/clone_test.go
+++ b/pkg/repository/clone_test.go
@@ -2,7 +2,9 @@ package repository
 
 import (
 	"context"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -13,6 +15,33 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/traefik/lobicornis/v3/pkg/conf"
 )
+
+// scheduleTempDirCleanup ensures dir is removed even when it contains git
+// pack/index files (written with 0444), which can defeat the default
+// t.TempDir cleanup on Linux runners. Registered after t.TempDir so it runs
+// first (cleanups are LIFO); the TempDir cleanup then sees an empty path.
+func scheduleTempDirCleanup(t *testing.T, dir string) {
+	t.Helper()
+	t.Cleanup(func() {
+		// Chdir out so the directory is not the process's cwd at unlink time.
+		// t.Chdir cannot be used here: it is only valid from the test body.
+		_ = os.Chdir(filepath.Dir(dir)) //nolint:usetesting
+
+		_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return nil //nolint:nilerr // continue walking, best-effort cleanup
+			}
+			mode := fs.FileMode(0o600)
+			if d.IsDir() {
+				mode = 0o700
+			}
+			_ = os.Chmod(path, mode) //nolint:gosec // G122: TOCTOU is not a concern on a test-owned temp dir
+			return nil
+		})
+
+		_ = os.RemoveAll(dir)
+	})
+}
 
 func TestClone_PullRequestForUpdate(t *testing.T) {
 	testCases := []struct {
@@ -48,6 +77,7 @@ func TestClone_PullRequestForUpdate(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
+			scheduleTempDirCleanup(t, dir)
 			t.Chdir(dir)
 
 			tempDir, err := os.Getwd()
@@ -109,6 +139,7 @@ func TestClone_PullRequestForMerge(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
+			scheduleTempDirCleanup(t, dir)
 			t.Chdir(dir)
 
 			tempDir, err := os.Getwd()

--- a/pkg/repository/mjolnir.go
+++ b/pkg/repository/mjolnir.go
@@ -11,13 +11,15 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// issueRefPattern matches a single issue reference: either `#NNN` or a full GitHub issue URL.
+const issueRefPattern = `(?:#\d+|https?://github\.com/[\w.-]+/[\w.-]+/issues/\d+)`
+
 // Mjolnir the hammer of Thor.
 type Mjolnir struct {
 	client *github.Client
 
 	globalFixesIssueRE *regexp.Regexp
-	fixesIssueRE       *regexp.Regexp
-	cleanNumberRE      *regexp.Regexp
+	issueRefRE         *regexp.Regexp
 
 	dryRun bool
 
@@ -29,9 +31,8 @@ func newMjolnir(client *github.Client, owner, name string, dryRun bool) Mjolnir 
 	return Mjolnir{
 		client: client,
 
-		globalFixesIssueRE: regexp.MustCompile(`(?i)(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)((?:[\s]+#[\d]+)(?:[\s,]+#[\d]+)*(?:[\n\r\s,]|$))`),
-		fixesIssueRE:       regexp.MustCompile(`[\s,]+#`),
-		cleanNumberRE:      regexp.MustCompile(`[\n\r\s,]`),
+		globalFixesIssueRE: regexp.MustCompile(`(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[\s:]+(` + issueRefPattern + `(?:[\s,]+` + issueRefPattern + `)*)`),
+		issueRefRE:         regexp.MustCompile(`#(\d+)|https?://github\.com/([\w.-]+)/([\w.-]+)/issues/(\d+)`),
 
 		dryRun: dryRun,
 
@@ -56,10 +57,10 @@ func (m Mjolnir) CloseRelatedIssues(ctx context.Context, pr *github.PullRequest)
 			}
 		}
 
-		// Add comment if needed
-
+		// On the main branch, GitHub auto-links the PR to the issue, so the
+		// "Closed by #X." comment is only useful for backport branches.
 		if pr.Base.GetRef() == mainBranch {
-			return nil
+			continue
 		}
 
 		message := fmt.Sprintf("Closed by #%d.", pr.GetNumber())
@@ -102,24 +103,44 @@ func (m Mjolnir) addComment(ctx context.Context, issueNumber int, message string
 }
 
 func (m Mjolnir) parseIssueFixes(ctx context.Context, text string) []int {
-	submatch := m.globalFixesIssueRE.FindStringSubmatch(strings.ReplaceAll(text, ":", ""))
+	logger := log.Ctx(ctx)
 
-	if len(submatch) == 0 {
+	matches := m.globalFixesIssueRE.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
 		return nil
 	}
 
-	issuesRaw := m.fixesIssueRE.Split(submatch[1], -1)
-
+	seen := make(map[int]bool)
 	var issueNumbers []int
-	for _, issueRaw := range issuesRaw {
-		cleanIssueRaw := m.cleanNumberRE.ReplaceAllString(issueRaw, "")
-		if len(cleanIssueRaw) != 0 {
-			numb, err := strconv.ParseInt(cleanIssueRaw, 10, 16)
-			if err != nil {
-				log.Ctx(ctx).Error().Err(err).Str("cleanIssueRaw", cleanIssueRaw).Msg("unable to parse int")
+	for _, group := range matches {
+		refs := m.issueRefRE.FindAllStringSubmatch(group[1], -1)
+		for _, ref := range refs {
+			// ref[1] is the `#NNN` form; ref[2]/[3]/[4] are owner/repo/number from the URL form.
+			var numStr string
+			switch {
+			case ref[1] != "":
+				numStr = ref[1]
+			case ref[4] != "":
+				if !strings.EqualFold(ref[2], m.owner) || !strings.EqualFold(ref[3], m.name) {
+					logger.Warn().Str("url", ref[0]).Msg("ignoring cross-repo issue reference")
+					continue
+				}
+				numStr = ref[4]
+			default:
+				continue
 			}
 
-			issueNumbers = append(issueNumbers, int(numb))
+			n, err := strconv.Atoi(numStr)
+			if err != nil {
+				logger.Error().Err(err).Str("number", numStr).Msg("unable to parse int")
+				continue
+			}
+
+			if seen[n] {
+				continue
+			}
+			seen[n] = true
+			issueNumbers = append(issueNumbers, n)
 		}
 	}
 	return issueNumbers

--- a/pkg/repository/mjolnir.go
+++ b/pkg/repository/mjolnir.go
@@ -14,6 +14,13 @@ import (
 // issueRefPattern matches a single issue reference: either `#NNN` or a full GitHub issue URL.
 const issueRefPattern = `(?:#\d+|https?://github\.com/[\w.-]+/[\w.-]+/issues/\d+)`
 
+// issueRef is a parsed issue reference scoped to a repository.
+type issueRef struct {
+	owner  string
+	name   string
+	number int
+}
+
 // Mjolnir the hammer of Thor.
 type Mjolnir struct {
 	client *github.Client
@@ -25,9 +32,19 @@ type Mjolnir struct {
 
 	owner string
 	name  string
+
+	// allowedRepos lists the repositories (owner/name, lowercased) authorized for
+	// cross-repo issue closing. An entry of the form "owner/*" allows the whole org.
+	// The PR's own repository is always allowed.
+	allowedRepos []string
 }
 
-func newMjolnir(client *github.Client, owner, name string, dryRun bool) Mjolnir {
+func newMjolnir(client *github.Client, owner, name string, dryRun bool, allowedRepos []string) Mjolnir {
+	normalized := make([]string, 0, len(allowedRepos))
+	for _, item := range allowedRepos {
+		normalized = append(normalized, strings.ToLower(item))
+	}
+
 	return Mjolnir{
 		client: client,
 
@@ -38,6 +55,8 @@ func newMjolnir(client *github.Client, owner, name string, dryRun bool) Mjolnir 
 
 		owner: owner,
 		name:  name,
+
+		allowedRepos: normalized,
 	}
 }
 
@@ -45,32 +64,34 @@ func newMjolnir(client *github.Client, owner, name string, dryRun bool) Mjolnir 
 func (m Mjolnir) CloseRelatedIssues(ctx context.Context, pr *github.PullRequest) error {
 	logger := log.Ctx(ctx)
 
-	issueNumbers := m.parseIssueFixes(ctx, pr.GetBody())
+	refs := m.parseIssueFixes(ctx, pr.GetBody())
 
-	for _, issueNumber := range issueNumbers {
-		logger.Info().Msgf("closes issue #%d, add milestones %s", issueNumber, pr.Milestone.GetTitle())
+	for _, ref := range refs {
+		logger.Info().Msgf("closes issue %s/%s#%d, add milestones %s", ref.owner, ref.name, ref.number, pr.Milestone.GetTitle())
 
 		if !m.dryRun {
-			err := m.closeIssue(ctx, pr, issueNumber)
+			err := m.closeIssue(ctx, pr, ref)
 			if err != nil {
-				return fmt.Errorf("unable to close issue #%d: %w", issueNumber, err)
+				return fmt.Errorf("unable to close issue %s/%s#%d: %w", ref.owner, ref.name, ref.number, err)
 			}
 		}
 
 		// On the main branch, GitHub auto-links the PR to the issue, so the
 		// "Closed by #X." comment is only useful for backport branches.
-		if pr.Base.GetRef() == mainBranch {
+		// The auto-link only fires for same-repo references; for cross-repo we
+		// always leave a back-pointer comment.
+		if ref.owner == m.owner && ref.name == m.name && pr.Base.GetRef() == mainBranch {
 			continue
 		}
 
-		message := fmt.Sprintf("Closed by #%d.", pr.GetNumber())
+		message := fmt.Sprintf("Closed by %s/%s#%d.", m.owner, m.name, pr.GetNumber())
 
-		logger.Debug().Msgf("issue #%d, add comment: %s", issueNumber, message)
+		logger.Debug().Msgf("issue %s/%s#%d, add comment: %s", ref.owner, ref.name, ref.number, message)
 
 		if !m.dryRun {
-			err := m.addComment(ctx, issueNumber, message)
+			err := m.addComment(ctx, ref, message)
 			if err != nil {
-				return fmt.Errorf("unable to add comment on issue #%d: %w", issueNumber, err)
+				return fmt.Errorf("unable to add comment on issue %s/%s#%d: %w", ref.owner, ref.name, ref.number, err)
 			}
 		}
 	}
@@ -78,31 +99,31 @@ func (m Mjolnir) CloseRelatedIssues(ctx context.Context, pr *github.PullRequest)
 	return nil
 }
 
-func (m Mjolnir) closeIssue(ctx context.Context, pr *github.PullRequest, issueNumber int) error {
-	var milestone *int
-	if pr.Milestone != nil {
-		milestone = pr.Milestone.Number
-	}
-
+func (m Mjolnir) closeIssue(ctx context.Context, pr *github.PullRequest, ref issueRef) error {
 	issueRequest := &github.IssueRequest{
-		Milestone: milestone,
-		State:     github.Ptr("closed"),
+		State: github.Ptr("closed"),
 	}
 
-	_, _, err := m.client.Issues.Edit(ctx, m.owner, m.name, issueNumber, issueRequest)
+	// Only carry the PR milestone over to issues in the same repository:
+	// milestone IDs are repo-scoped and would be invalid elsewhere.
+	if pr.Milestone != nil && ref.owner == m.owner && ref.name == m.name {
+		issueRequest.Milestone = pr.Milestone.Number
+	}
+
+	_, _, err := m.client.Issues.Edit(ctx, ref.owner, ref.name, ref.number, issueRequest)
 	return err
 }
 
-func (m Mjolnir) addComment(ctx context.Context, issueNumber int, message string) error {
+func (m Mjolnir) addComment(ctx context.Context, ref issueRef, message string) error {
 	issueComment := &github.IssueComment{
 		Body: github.Ptr(message),
 	}
 
-	_, _, err := m.client.Issues.CreateComment(ctx, m.owner, m.name, issueNumber, issueComment)
+	_, _, err := m.client.Issues.CreateComment(ctx, ref.owner, ref.name, ref.number, issueComment)
 	return err
 }
 
-func (m Mjolnir) parseIssueFixes(ctx context.Context, text string) []int {
+func (m Mjolnir) parseIssueFixes(ctx context.Context, text string) []issueRef {
 	logger := log.Ctx(ctx)
 
 	matches := m.globalFixesIssueRE.FindAllStringSubmatch(text, -1)
@@ -110,22 +131,26 @@ func (m Mjolnir) parseIssueFixes(ctx context.Context, text string) []int {
 		return nil
 	}
 
-	seen := make(map[int]bool)
-	var issueNumbers []int
+	type key struct {
+		owner, name string
+		number      int
+	}
+	seen := make(map[key]bool)
+	var refs []issueRef
 	for _, group := range matches {
-		refs := m.issueRefRE.FindAllStringSubmatch(group[1], -1)
-		for _, ref := range refs {
-			// ref[1] is the `#NNN` form; ref[2]/[3]/[4] are owner/repo/number from the URL form.
-			var numStr string
+		found := m.issueRefRE.FindAllStringSubmatch(group[1], -1)
+		for _, raw := range found {
+			// raw[1] is the `#NNN` form; raw[2]/[3]/[4] are owner/repo/number from the URL form.
+			var owner, name, numStr string
 			switch {
-			case ref[1] != "":
-				numStr = ref[1]
-			case ref[4] != "":
-				if !strings.EqualFold(ref[2], m.owner) || !strings.EqualFold(ref[3], m.name) {
-					logger.Warn().Str("url", ref[0]).Msg("ignoring cross-repo issue reference")
+			case raw[1] != "":
+				owner, name, numStr = m.owner, m.name, raw[1]
+			case raw[4] != "":
+				owner, name, numStr = raw[2], raw[3], raw[4]
+				if !m.repoAllowed(owner, name) {
+					logger.Warn().Str("url", raw[0]).Msg("ignoring issue reference: repository not in closeIssuesFrom allow-list")
 					continue
 				}
-				numStr = ref[4]
 			default:
 				continue
 			}
@@ -136,12 +161,31 @@ func (m Mjolnir) parseIssueFixes(ctx context.Context, text string) []int {
 				continue
 			}
 
-			if seen[n] {
+			k := key{owner: strings.ToLower(owner), name: strings.ToLower(name), number: n}
+			if seen[k] {
 				continue
 			}
-			seen[n] = true
-			issueNumbers = append(issueNumbers, n)
+			seen[k] = true
+			refs = append(refs, issueRef{owner: owner, name: name, number: n})
 		}
 	}
-	return issueNumbers
+	return refs
+}
+
+// repoAllowed reports whether issues in owner/name may be auto-closed.
+// The PR's own repository is always allowed; cross-repo references must match
+// an entry in allowedRepos, either exactly ("owner/name") or via an org wildcard ("owner/*").
+func (m Mjolnir) repoAllowed(owner, name string) bool {
+	if strings.EqualFold(owner, m.owner) && strings.EqualFold(name, m.name) {
+		return true
+	}
+
+	target := strings.ToLower(owner + "/" + name)
+	orgWildcard := strings.ToLower(owner) + "/*"
+	for _, allowed := range m.allowedRepos {
+		if allowed == target || allowed == orgWildcard {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/repository/mjolnir.go
+++ b/pkg/repository/mjolnir.go
@@ -148,7 +148,7 @@ func (m Mjolnir) parseIssueFixes(ctx context.Context, text string) []issueRef {
 			case raw[4] != "":
 				owner, name, numStr = raw[2], raw[3], raw[4]
 				if !m.repoAllowed(owner, name) {
-					logger.Warn().Str("url", raw[0]).Msg("ignoring issue reference: repository not in closeIssuesFrom allow-list")
+					logger.Warn().Str("url", raw[0]).Msg("ignoring issue reference: repository not in allowCloseIssuesOn allow-list")
 					continue
 				}
 			default:

--- a/pkg/repository/mjolnir.go
+++ b/pkg/repository/mjolnir.go
@@ -76,11 +76,11 @@ func (m Mjolnir) CloseRelatedIssues(ctx context.Context, pr *github.PullRequest)
 			}
 		}
 
-		// On the main branch, GitHub auto-links the PR to the issue, so the
+		// On the default branch, GitHub auto-links the PR to the issue, so the
 		// "Closed by #X." comment is only useful for backport branches.
 		// The auto-link only fires for same-repo references; for cross-repo we
 		// always leave a back-pointer comment.
-		if ref.owner == m.owner && ref.name == m.name && pr.Base.GetRef() == mainBranch {
+		if m.isAutoLinked(pr, ref) {
 			continue
 		}
 
@@ -97,6 +97,14 @@ func (m Mjolnir) CloseRelatedIssues(ctx context.Context, pr *github.PullRequest)
 	}
 
 	return nil
+}
+
+// isAutoLinked reports whether GitHub auto-links the PR to the referenced issue,
+// which makes the explicit "Closed by #X." back-pointer comment redundant.
+// The auto-link only fires for same-repository references merged into the
+// repository default branch (which may be "main", "master", or custom).
+func (m Mjolnir) isAutoLinked(pr *github.PullRequest, ref issueRef) bool {
+	return ref.owner == m.owner && ref.name == m.name && pr.Base.GetRef() == pr.Base.GetRepo().GetDefaultBranch()
 }
 
 func (m Mjolnir) closeIssue(ctx context.Context, pr *github.PullRequest, ref issueRef) error {

--- a/pkg/repository/mjolnir_test.go
+++ b/pkg/repository/mjolnir_test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/go-github/v74/github"
 	"github.com/stretchr/testify/assert"
 )
 
 const (
 	testOwner = "owner"
 	testRepo  = "repo"
+
+	branchMain = "main"
 )
 
 func Test_parseIssueFixes(t *testing.T) {
@@ -216,6 +219,78 @@ func Test_parseIssueFixes(t *testing.T) {
 			refs := mjolnir.parseIssueFixes(context.Background(), test.text)
 
 			assert.Equal(t, test.expected, refs)
+		})
+	}
+}
+
+func Test_isAutoLinked(t *testing.T) {
+	testCases := []struct {
+		name          string
+		baseRef       string
+		defaultBranch string
+		ref           issueRef
+		expected      bool
+	}{
+		{
+			name:          "same repo on default branch master",
+			baseRef:       "master",
+			defaultBranch: "master",
+			ref:           issueRef{owner: testOwner, name: testRepo, number: 1},
+			expected:      true,
+		},
+		{
+			name:          "same repo on default branch main",
+			baseRef:       branchMain,
+			defaultBranch: branchMain,
+			ref:           issueRef{owner: testOwner, name: testRepo, number: 1},
+			expected:      true,
+		},
+		{
+			name:          "same repo on custom default branch",
+			baseRef:       "develop",
+			defaultBranch: "develop",
+			ref:           issueRef{owner: testOwner, name: testRepo, number: 1},
+			expected:      true,
+		},
+		{
+			name:          "same repo on non-default branch",
+			baseRef:       "v1.0",
+			defaultBranch: branchMain,
+			ref:           issueRef{owner: testOwner, name: testRepo, number: 1},
+			expected:      false,
+		},
+		{
+			name:          "cross-repo on default branch",
+			baseRef:       branchMain,
+			defaultBranch: branchMain,
+			ref:           issueRef{owner: testOwner, name: "other-repo", number: 1},
+			expected:      false,
+		},
+		{
+			name:          "cross-org on default branch",
+			baseRef:       branchMain,
+			defaultBranch: branchMain,
+			ref:           issueRef{owner: "other", name: testRepo, number: 1},
+			expected:      false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			mjolnir := newMjolnir(nil, testOwner, testRepo, true, nil)
+
+			pr := &github.PullRequest{
+				Base: &github.PullRequestBranch{
+					Ref: github.Ptr(test.baseRef),
+					Repo: &github.Repository{
+						DefaultBranch: github.Ptr(test.defaultBranch),
+					},
+				},
+			}
+
+			assert.Equal(t, test.expected, mjolnir.isAutoLinked(pr, test.ref))
 		})
 	}
 }

--- a/pkg/repository/mjolnir_test.go
+++ b/pkg/repository/mjolnir_test.go
@@ -39,7 +39,7 @@ func Test_parseIssueFixes(t *testing.T) {
 			text: `
 	Fixes #13#14,#15,#16,
 `,
-			expectedNumbers: nil,
+			expectedNumbers: []int{13},
 		},
 		{
 			name: "french style",
@@ -55,9 +55,62 @@ func Test_parseIssueFixes(t *testing.T) {
 `,
 			expectedNumbers: []int{13, 14, 15, 16},
 		},
+		{
+			name: "multiple separate fixes blocks",
+			text: `
+	This partially fixes #11375 by proposing an alternative.
+	Fixes #12786
+`,
+			expectedNumbers: []int{11375, 12786},
+		},
+		{
+			name: "URL form same repo",
+			text: `
+	Fixes https://github.com/owner/repo/issues/12820
+	Fixes https://github.com/owner/repo/issues/12748
+`,
+			expectedNumbers: []int{12820, 12748},
+		},
+		{
+			name: "URL form cross-repo ignored",
+			text: `
+	Fixes https://github.com/other/different/issues/9999
+`,
+			expectedNumbers: nil,
+		},
+		{
+			name: "mixed hash and URL",
+			text: `
+	Closes #100, https://github.com/owner/repo/issues/200
+`,
+			expectedNumbers: []int{100, 200},
+		},
+		{
+			name: "trailing period",
+			text: `
+	Closes #12956.
+`,
+			expectedNumbers: []int{12956},
+		},
+		{
+			name: "closed and resolved keywords",
+			text: `
+	Closed #1
+	Resolved #2
+`,
+			expectedNumbers: []int{1, 2},
+		},
+		{
+			name: "deduplicate same issue",
+			text: `
+	Fixes #13 #13
+	Closes #13
+`,
+			expectedNumbers: []int{13},
+		},
 	}
 
-	mjolnir := newMjolnir(nil, "", "", true)
+	mjolnir := newMjolnir(nil, "owner", "repo", true)
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/repository/mjolnir_test.go
+++ b/pkg/repository/mjolnir_test.go
@@ -7,53 +7,81 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	testOwner = "owner"
+	testRepo  = "repo"
+)
+
 func Test_parseIssueFixes(t *testing.T) {
 	testCases := []struct {
-		name            string
-		text            string
-		expectedNumbers []int
+		name         string
+		text         string
+		allowedRepos []string
+		expected     []issueRef
 	}{
 		{
 			name: "only letters",
 			text: `
 	Fixes dlsqj
 `,
-			expectedNumbers: nil,
+			expected: nil,
 		},
 		{
 			name: "valid issue numbers coma",
 			text: `
 	Fixes #13 #14, #15,#16,
 `,
-			expectedNumbers: []int{13, 14, 15, 16},
+			expected: []issueRef{
+				{owner: testOwner, name: testRepo, number: 13},
+				{owner: testOwner, name: testRepo, number: 14},
+				{owner: testOwner, name: testRepo, number: 15},
+				{owner: testOwner, name: testRepo, number: 16},
+			},
 		},
 		{
 			name: "valid issue numbers space",
 			text: `
 	Fixes #13 #14 #15 #16
 `,
-			expectedNumbers: []int{13, 14, 15, 16},
+			expected: []issueRef{
+				{owner: testOwner, name: testRepo, number: 13},
+				{owner: testOwner, name: testRepo, number: 14},
+				{owner: testOwner, name: testRepo, number: 15},
+				{owner: testOwner, name: testRepo, number: 16},
+			},
 		},
 		{
 			name: "invalid pattern",
 			text: `
 	Fixes #13#14,#15,#16,
 `,
-			expectedNumbers: []int{13},
+			expected: []issueRef{
+				{owner: testOwner, name: testRepo, number: 13},
+			},
 		},
 		{
 			name: "french style",
 			text: `
 	Fixes : #13,#14,#15,#16,
 `,
-			expectedNumbers: []int{13, 14, 15, 16},
+			expected: []issueRef{
+				{owner: testOwner, name: testRepo, number: 13},
+				{owner: testOwner, name: testRepo, number: 14},
+				{owner: testOwner, name: testRepo, number: 15},
+				{owner: testOwner, name: testRepo, number: 16},
+			},
 		},
 		{
 			name: "valid issue numbers coma and :",
 			text: `
 	Fixes: #13,#14,#15,#16,
 `,
-			expectedNumbers: []int{13, 14, 15, 16},
+			expected: []issueRef{
+				{owner: testOwner, name: testRepo, number: 13},
+				{owner: testOwner, name: testRepo, number: 14},
+				{owner: testOwner, name: testRepo, number: 15},
+				{owner: testOwner, name: testRepo, number: 16},
+			},
 		},
 		{
 			name: "multiple separate fixes blocks",
@@ -61,7 +89,10 @@ func Test_parseIssueFixes(t *testing.T) {
 	This partially fixes #11375 by proposing an alternative.
 	Fixes #12786
 `,
-			expectedNumbers: []int{11375, 12786},
+			expected: []issueRef{
+				{owner: testOwner, name: testRepo, number: 11375},
+				{owner: testOwner, name: testRepo, number: 12786},
+			},
 		},
 		{
 			name: "URL form same repo",
@@ -69,28 +100,79 @@ func Test_parseIssueFixes(t *testing.T) {
 	Fixes https://github.com/owner/repo/issues/12820
 	Fixes https://github.com/owner/repo/issues/12748
 `,
-			expectedNumbers: []int{12820, 12748},
+			expected: []issueRef{
+				{owner: testOwner, name: testRepo, number: 12820},
+				{owner: testOwner, name: testRepo, number: 12748},
+			},
 		},
 		{
-			name: "URL form cross-repo ignored",
+			name: "URL form cross-repo denied by default",
 			text: `
 	Fixes https://github.com/other/different/issues/9999
 `,
-			expectedNumbers: nil,
+			expected: nil,
+		},
+		{
+			name: "URL form cross-repo allowed explicitly",
+			text: `
+	Fixes https://github.com/owner/hub-issues/issues/42
+`,
+			allowedRepos: []string{"owner/hub-issues"},
+			expected: []issueRef{
+				{owner: testOwner, name: "hub-issues", number: 42},
+			},
+		},
+		{
+			name: "URL form cross-org allowed explicitly",
+			text: `
+	Fixes https://github.com/other/different/issues/9999
+`,
+			allowedRepos: []string{"other/different"},
+			expected: []issueRef{
+				{owner: "other", name: "different", number: 9999},
+			},
+		},
+		{
+			name: "URL form org wildcard",
+			text: `
+	Fixes https://github.com/owner/sibling/issues/7
+	Fixes https://github.com/owner/another/issues/8
+`,
+			allowedRepos: []string{"owner/*"},
+			expected: []issueRef{
+				{owner: testOwner, name: "sibling", number: 7},
+				{owner: testOwner, name: "another", number: 8},
+			},
+		},
+		{
+			name: "URL form allow-list does not match unrelated repo",
+			text: `
+	Fixes https://github.com/owner/hub-issues/issues/1
+	Fixes https://github.com/owner/stranger/issues/2
+`,
+			allowedRepos: []string{"owner/hub-issues"},
+			expected: []issueRef{
+				{owner: testOwner, name: "hub-issues", number: 1},
+			},
 		},
 		{
 			name: "mixed hash and URL",
 			text: `
 	Closes #100, https://github.com/owner/repo/issues/200
 `,
-			expectedNumbers: []int{100, 200},
+			expected: []issueRef{
+				{owner: testOwner, name: testRepo, number: 100},
+				{owner: testOwner, name: testRepo, number: 200},
+			},
 		},
 		{
 			name: "trailing period",
 			text: `
 	Closes #12956.
 `,
-			expectedNumbers: []int{12956},
+			expected: []issueRef{
+				{owner: testOwner, name: testRepo, number: 12956},
+			},
 		},
 		{
 			name: "closed and resolved keywords",
@@ -98,7 +180,10 @@ func Test_parseIssueFixes(t *testing.T) {
 	Closed #1
 	Resolved #2
 `,
-			expectedNumbers: []int{1, 2},
+			expected: []issueRef{
+				{owner: testOwner, name: testRepo, number: 1},
+				{owner: testOwner, name: testRepo, number: 2},
+			},
 		},
 		{
 			name: "deduplicate same issue",
@@ -106,19 +191,31 @@ func Test_parseIssueFixes(t *testing.T) {
 	Fixes #13 #13
 	Closes #13
 `,
-			expectedNumbers: []int{13},
+			expected: []issueRef{
+				{owner: testOwner, name: testRepo, number: 13},
+			},
+		},
+		{
+			name: "deduplicate hash and URL referring to same issue",
+			text: `
+	Fixes #42
+	Closes https://github.com/owner/repo/issues/42
+`,
+			expected: []issueRef{
+				{owner: testOwner, name: testRepo, number: 42},
+			},
 		},
 	}
-
-	mjolnir := newMjolnir(nil, "owner", "repo", true)
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			issueNumbers := mjolnir.parseIssueFixes(context.Background(), test.text)
+			mjolnir := newMjolnir(nil, testOwner, testRepo, true, test.allowedRepos)
 
-			assert.Equal(t, test.expectedNumbers, issueNumbers)
+			refs := mjolnir.parseIssueFixes(context.Background(), test.text)
+
+			assert.Equal(t, test.expected, refs)
 		})
 	}
 }

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -48,7 +48,7 @@ func New(client *github.Client, fullName, token string, markers conf.Markers, re
 	return &Repository{
 		client:  client,
 		clone:   newClone(gitConfig, token),
-		mjolnir: newMjolnir(client, owner, repoName, extra.DryRun, config.GetCloseIssuesFrom()),
+		mjolnir: newMjolnir(client, owner, repoName, extra.DryRun, config.GetAllowCloseIssuesOn()),
 		dryRun:  extra.DryRun,
 		markers: markers,
 		retry:   retry,

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -48,7 +48,7 @@ func New(client *github.Client, fullName, token string, markers conf.Markers, re
 	return &Repository{
 		client:  client,
 		clone:   newClone(gitConfig, token),
-		mjolnir: newMjolnir(client, owner, repoName, extra.DryRun),
+		mjolnir: newMjolnir(client, owner, repoName, extra.DryRun, config.GetCloseIssuesFrom()),
 		dryRun:  extra.DryRun,
 		markers: markers,
 		retry:   retry,

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -11,8 +11,6 @@ import (
 	"github.com/traefik/lobicornis/v3/pkg/conf"
 )
 
-const mainBranch = "master"
-
 type numbered interface {
 	GetNumber() int
 }

--- a/pkg/repository/repository_update.go
+++ b/pkg/repository/repository_update.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -70,8 +69,8 @@ func (r *Repository) cloneAndUpdate(ctx context.Context, pr *github.PullRequest)
 	tempDir, _ := os.Getwd()
 	logger.Info().Msg(tempDir)
 
-	if isOnMainRepository(pr) && pr.Head.GetRef() == mainBranch {
-		return errors.New("the branch master on a main repository cannot be rebased")
+	if isOnMainRepository(pr) && pr.Head.GetRef() == pr.Base.GetRepo().GetDefaultBranch() {
+		return fmt.Errorf("the default branch %q on a main repository cannot be rebased", pr.Head.GetRef())
 	}
 
 	mainRemote, err := r.clone.PullRequestForUpdate(ctx, pr)

--- a/readme.md
+++ b/readme.md
@@ -112,6 +112,10 @@ default:
   addErrorInComment: false
   # When the merge method is squash, define the strategy to create the commit message. (github|empty|description)
   commitMessage: empty
+  # External repositories whose issues may be auto-closed from a merged PR body.
+  # Entries are of the form "owner/repo", or "owner/*" to allow a whole org.
+  # The PR's own repository is always allowed; only cross-repo references need to be listed here.
+  closeIssuesFrom: []
 
 # defines override of the default configuration by repository.
 repositories:
@@ -123,6 +127,9 @@ repositories:
     minLightReview: 1
     minReview: 1
     needMilestone: false
+    closeIssuesFrom:
+      - foo/hub-issues
+      - foo/*
 ```
 
 ## Examples

--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ repositories:
     minReview: 1
     needMilestone: false
     allowCloseIssuesOn:
-      - foo/hub-issues
+      - foo/other-repo
       - foo/*
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -115,7 +115,7 @@ default:
   # External repositories whose issues may be auto-closed from a merged PR body.
   # Entries are of the form "owner/repo", or "owner/*" to allow a whole org.
   # The PR's own repository is always allowed; only cross-repo references need to be listed here.
-  closeIssuesFrom: []
+  allowCloseIssuesOn: []
 
 # defines override of the default configuration by repository.
 repositories:
@@ -127,7 +127,7 @@ repositories:
     minLightReview: 1
     minReview: 1
     needMilestone: false
-    closeIssuesFrom:
+    allowCloseIssuesOn:
       - foo/hub-issues
       - foo/*
 ```


### PR DESCRIPTION
### What does this PR do?

Fix the issue parser in `mjolnir.go` so that all issues referenced from a merged PR body are closed, not just the first one. The previous parser:

- used `FindStringSubmatch`, capturing only the first `Fixes/Closes/Resolves` group — additional groups elsewhere in the body were silently dropped;
- only matched the `#NNN` form, missing GitHub issue URLs (`https://github.com/owner/repo/issues/NNN`);
- broke on trailing punctuation such as `Closes #12956.`;
- stripped all `:` from the body before matching, which would also have broken URLs (`https://` → `https//`).

### Motivation

Several recent Traefik backports merged on `v3.7` failed to close their referenced issues:

- traefik/traefik#12884 — `Fixes #11375` and `Fixes #12786` in separate paragraphs; only `#11375` was closed.
- traefik/traefik#12831, traefik/traefik#12986, traefik/traefik#12969 — `Fixes https://github.com/.../issues/NNN` (URL form); none were closed.
- traefik/traefik#12978 — `Closes #12956.` (trailing period); not closed.